### PR TITLE
Make writing OS certs & trust chains optional

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -116,5 +116,7 @@ venv.bak/
 aviator_pipeline.yml
 
 # Terraform
-ci/.terraform
-ci/terraform.*
+**/.terraform/
+**/*.tfvars
+**/*.tfstate
+**/*.tfstate*

--- a/.gitignore
+++ b/.gitignore
@@ -114,3 +114,7 @@ venv.bak/
 
 # Concourse CI
 aviator_pipeline.yml
+
+# Terraform
+ci/.terraform
+ci/terraform.*

--- a/src/acm_cert_retriever/retriever.py
+++ b/src/acm_cert_retriever/retriever.py
@@ -115,7 +115,7 @@ def parse_args(args):
     )
     p.add(
         "--jks-only",
-        default=False
+        default=False,
         type=str2bool,
         env_var="RETRIEVER_JKS_ONLY",
         help="Only generate the Java KeyStores; don't update the OS trustchains "

--- a/src/acm_cert_retriever/retriever.py
+++ b/src/acm_cert_retriever/retriever.py
@@ -114,6 +114,14 @@ def parse_args(args):
              "entries in the Java TrustStore",
     )
     p.add(
+        "--jks-only",
+        default=False
+        type=str2bool,
+        env_var="RETRIEVER_JKS_ONLY",
+        help="Only generate the Java KeyStores; don't update the OS trustchains "
+            "(which requires this utility to be run as root)"
+    )
+    p.add(
         "--log-level",
         choices=["CRITICAL", "ERROR", "WARNING", "INFO", "DEBUG"],
         default="INFO",
@@ -201,10 +209,10 @@ def create_stores(args, cert_and_key_data, s3_util, truststore_util):
     logger.info("Created KeyStore and TrustStore")
 
 
-def update_ca_trust(
+def update_os_ca_trust(
     s3_util, truststore_util, args, cert_and_key
 ):
-    """Place retrieved key and cert in ca trust.
+    """Place retrieved key and cert in the OS CA trust chain.
 
     Args:
         s3_util (Object): The boto3 utility to use
@@ -245,7 +253,8 @@ def retrieve_key_and_cert_and_make_stores(acm_util, s3_util, truststore_util,
     if (args.keystore_path is not None) and (args.truststore_path is not None):
         create_stores(args, cert_and_key, s3_util, truststore_util)
 
-    update_ca_trust(s3_util, truststore_util, args, cert_and_key)
+    if  not args.jks_only:
+        update_os_ca_trust(s3_util, truststore_util, args, cert_and_key)
 
 
 def _main(args):

--- a/src/acm_cert_retriever/retriever.py
+++ b/src/acm_cert_retriever/retriever.py
@@ -119,7 +119,7 @@ def parse_args(args):
         type=str2bool,
         env_var="RETRIEVER_JKS_ONLY",
         help="Only generate the Java KeyStores; don't update the OS trustchains "
-            "(which requires this utility to be run as root)"
+             "(which requires this utility to be run as root)"
     )
     p.add(
         "--log-level",
@@ -253,7 +253,7 @@ def retrieve_key_and_cert_and_make_stores(acm_util, s3_util, truststore_util,
     if (args.keystore_path is not None) and (args.truststore_path is not None):
         create_stores(args, cert_and_key, s3_util, truststore_util)
 
-    if  not args.jks_only:
+    if not args.jks_only:
         update_os_ca_trust(s3_util, truststore_util, args, cert_and_key)
 
 

--- a/src/acm_common/truststore_utils.py
+++ b/src/acm_common/truststore_utils.py
@@ -147,9 +147,6 @@ def add_cert_and_key(
         with open("/etc/pki/tls/certs/" + alias + ".crt", "a") as f:
             f.write(cert)
 
-    logger.info("Updating CA trust")
-    os.system("update-ca-trust")
-
 
 def parse_s3_url(url):
     """Extract the S3 bucket name and key from a given S3 URL.

--- a/src/acm_pca_cert_generator/certgen.py
+++ b/src/acm_pca_cert_generator/certgen.py
@@ -245,6 +245,14 @@ def parse_args(args):
              "entries in the Java TrustStore",
     )
     p.add(
+        "--jks-only",
+        default=False
+        type=str2bool,
+        env_var="CERTGEN_JKS_ONLY",
+        help="Only generate the Java KeyStores; don't update the OS trustchains "
+            "(which requires this utility to be run as root)"
+    )
+    p.add(
         "--log-level",
         choices=["CRITICAL", "ERROR", "WARNING", "INFO", "DEBUG"],
         default="INFO",
@@ -417,15 +425,15 @@ def generate_key_and_cert(
         generate_key_and_trust_store(s3_util, truststore_util, args,
                                      key, cert_and_chain)
 
-    update_ca_trust(s3_util, truststore_util, args,
-                    key, cert_and_chain)
+    if not args.jks_only:
+        update_os_ca_trust(s3_util, truststore_util, args, key, cert_and_chain)
 
 
-def update_ca_trust(
+def update_os_ca_trust(
     s3_util, truststore_util, args,
     key, cert_and_chain
 ):
-    """Place generated key and cert in ca trust.
+    """Place generated key and cert in OS CA trust.
 
     Args:
         s3_util (Object): The boto3 utility to use

--- a/src/acm_pca_cert_generator/certgen.py
+++ b/src/acm_pca_cert_generator/certgen.py
@@ -32,6 +32,7 @@ def str2bool(v):
     else:
         raise configargparse.ArgumentTypeError('Boolean value expected.')
 
+
 def check_key_length(value):
     """Check that a valid key length has been provided.
 

--- a/src/acm_pca_cert_generator/certgen.py
+++ b/src/acm_pca_cert_generator/certgen.py
@@ -16,6 +16,22 @@ subject_name_parts = ["C", "ST", "L", "O", "OU", "CN", "emailAddress"]
 pem_type = OpenSSL.crypto.FILETYPE_PEM
 
 
+def str2bool(v):
+    """Parse the supplied command line arguments into a boolean.
+
+    Returns:
+        Boolean: The parsed and validated command line arguments. Defaults to False.
+
+    """
+    if isinstance(v, bool):
+        return v
+    if v.lower() in ('yes', 'true', '1'):
+        return True
+    elif v.lower() in ('no', 'false', '0'):
+        return False
+    else:
+        raise configargparse.ArgumentTypeError('Boolean value expected.')
+
 def check_key_length(value):
     """Check that a valid key length has been provided.
 
@@ -250,7 +266,7 @@ def parse_args(args):
         type=str2bool,
         env_var="CERTGEN_JKS_ONLY",
         help="Only generate the Java KeyStores; don't update the OS trustchains "
-            "(which requires this utility to be run as root)"
+             "(which requires this utility to be run as root)"
     )
     p.add(
         "--log-level",

--- a/src/acm_pca_cert_generator/certgen.py
+++ b/src/acm_pca_cert_generator/certgen.py
@@ -246,7 +246,7 @@ def parse_args(args):
     )
     p.add(
         "--jks-only",
-        default=False
+        default=False,
         type=str2bool,
         env_var="CERTGEN_JKS_ONLY",
         help="Only generate the Java KeyStores; don't update the OS trustchains "

--- a/tests/test_certgen_wiring.py
+++ b/tests/test_certgen_wiring.py
@@ -47,6 +47,7 @@ template_args = {
     "truststore_password": "my-truststore-password",
     "truststore_aliases": "my-truststore-aliases",
     "truststore_certs": "my-truststore-certs",
+    "jks_only": "true",
     "log_level": "ANY"
 }
 

--- a/tests/test_retriever.py
+++ b/tests/test_retriever.py
@@ -30,6 +30,7 @@ template_args = {
     "truststore_password": "my-truststore-password",
     "truststore_aliases": "my-truststore-aliases",
     "truststore_certs": "my-truststore-certs",
+    "jks_only": "False",
     "log_level": "ANY"
 }
 


### PR DESCRIPTION
When run on an EMR cluster, during a step, the utility is executed as a
non-root user. They don't have permissions to alter on-disk certs, keys,
and trust chains, so allow that step to be skipped.