### PR TITLE
Add manual trigger due to path restrictions

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -10,7 +10,8 @@ on:
       - ".circleci/**"
       - ".github/workflows/**"
       - "ci/**"
-
+  workflow_dispatch:
+    
 env:
   IMAGE_NAME: dwpdigital/acm-cert-helper
 


### PR DESCRIPTION
Due to path restrictions in the workflows, a manual trigger is required for changes made to ignored files/paths.