### PR TITLE
Install pkg for uuidgen

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,8 @@ RUN apk add --update --no-cache \
     curl \
     aws-cli \
     gcc \
-    musl-dev
+    musl-dev \
+    util-linux
 
 # Download acm-cert-helper
 RUN curl -k -LSs --output /tmp/acm_cert_helper.tar.gz \


### PR DESCRIPTION
Cert helper requires `uuidgen` when it runs.  This installs that for Alpine.